### PR TITLE
Updates the implementation to match the refactor that will be added in gutenberg 17.6

### DIFF
--- a/collection.json
+++ b/collection.json
@@ -1,100 +1,173 @@
 {
-  "fontFamilies": [
+  "$schema": "https://schemas.wp.org/trunk/font-collection.json",
+  "categories": [
     {
-      "name": "System UI",
-      "fontFamily": "system-ui, sans-serif",
-      "slug": "system-ui",
-      "category": "sans-serif"
+      "slug": "sans-serif",
+      "name": "Sans Serif"
     },
     {
-      "name": "Transitional",
-      "fontFamily": "Charter, 'Bitstream Charter', 'Sitka Text', Cambria, serif",
-      "slug": "transitional",
-      "category": "serif"
+      "slug": "serif",
+      "name": "Serif"
     },
     {
-      "name": "Old Style",
-      "fontFamily": "'Iowan Old Style', 'Palatino Linotype', 'URW Palladio L', P052, serif",
-      "slug": "old-style",
-      "category": "serif"
+      "slug": "monospace",
+      "name": "Monospace"
     },
     {
-      "name": "Humanist",
-      "fontFamily": "Seravek, 'Gill Sans Nova', Ubuntu, Calibri, 'DejaVu Sans', source-sans-pro, sans-serif",
-      "slug": "humanist",
-      "category": "sans-serif"
-    },
-    {
-      "name": "Geometric Humanist",
-      "fontFamily": "Avenir, Montserrat, Corbel, 'URW Gothic', source-sans-pro, sans-serif",
-      "slug": "geometric-humanist",
-      "category": "sans-serif"
-    },
-    {
-      "name": "Classical Humanist",
-      "fontFamily": "Optima, Candara, 'Noto Sans', source-sans-pro, sans-serif",
-      "slug": "classical-humanist",
-      "category": "sans-serif"
-    },
-    {
-      "name": "Neo-Grotesque",
-      "fontFamily": "Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif",
-      "slug": "neo-grotesque",
-      "category": "sans-serif"
-    },
-    {
-      "name": "Monospace Slab Serif",
-      "fontFamily": "'Nimbus Mono PS', 'Courier New', monospace",
-      "slug": "monospace-slab-serif",
-      "category": "monospace"
-    },
-    {
-      "name": "Monospace Code",
-      "fontFamily": "ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
-      "slug": "monospace-code",
-      "category": "monospace"
-    },
-    {
-      "name": "Industrial",
-      "fontFamily": "Bahnschrift, 'DIN Alternate', 'Franklin Gothic Medium', 'Nimbus Sans Narrow', sans-serif-condensed, sans-serif",
-      "slug": "industrial",
-      "category": "sans-serif"
-    },
-    {
-      "name": "Rounded Sans",
-      "fontFamily": "ui-rounded, 'Hiragino Maru Gothic ProN', Quicksand, Comfortaa, Manjari, 'Arial Rounded MT', 'Arial Rounded MT Bold', Calibri, source-sans-pro, sans-serif",
-      "slug": "rounded-sans",
-      "category": "sans-serif"
-    },
-    {
-      "name": "Slab Serif",
-      "fontFamily": "Rockwell, 'Rockwell Nova', 'Roboto Slab', 'DejaVu Serif', 'Sitka Small', serif",
-      "slug": "slab-serif",
-      "category": "serif"
-    },
-    {
-      "name": "Antique",
-      "fontFamily": "Superclarendon, 'Bookman Old Style', 'URW Bookman', 'URW Bookman L', 'Georgia Pro', Georgia, serif",
-      "slug": "antique",
-      "category": "serif"
-    },
-    {
-      "name": "Didone",
-      "fontFamily": "Didot, 'Bodoni MT', 'Noto Serif Display', 'URW Palladio L', P052, Sylfaen, serif",
-      "slug": "didone",
-      "category": "serif"
-    },
-    {
-      "name": "Handwritten",
-      "fontFamily": "'Segoe Print', 'Bradley Hand', Chilanka, TSCu_Comic, casual, cursive",
-      "slug": "handwritten",
-      "category": "handwriting"
+      "slug": "handwriting",
+      "name": "Handwriting"
     }
   ],
-  "categories": [
-    { "id": "sans-serif", "name": "Sans Serif" },
-    { "id": "serif", "name": "Serif" },
-    { "id": "monospace", "name": "Monospace" },
-    { "id": "handwriting", "name": "Handwriting" }
+  "font_families": [
+    {
+      "font_family_settings": {
+        "fontFamily": "system-ui, sans-serif",
+        "slug": "system-ui",
+        "name": "System UI"
+      },
+      "categories": [
+        "sans-serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "Charter, 'Bitstream Charter', 'Sitka Text', Cambria, serif",
+        "slug": "transitional",
+        "name": "Transitional"
+      },
+      "categories": [
+        "serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "'Iowan Old Style', 'Palatino Linotype', 'URW Palladio L', P052, serif",
+        "slug": "old-style",
+        "name": "Old Style"
+      },
+      "categories": [
+        "serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "Seravek, 'Gill Sans Nova', Ubuntu, Calibri, 'DejaVu Sans', source-sans-pro, sans-serif",
+        "slug": "humanist",
+        "name": "Humanist"
+      },
+      "categories": [
+        "sans-serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "Avenir, Montserrat, Corbel, 'URW Gothic', source-sans-pro, sans-serif",
+        "slug": "geometric-humanist",
+        "name": "Geometric Humanist"
+      },
+      "categories": [
+        "sans-serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "Optima, Candara, 'Noto Sans', source-sans-pro, sans-serif",
+        "slug": "classical-humanist",
+        "name": "Classical Humanist"
+      },
+      "categories": [
+        "sans-serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "Inter, Roboto, 'Helvetica Neue', 'Arial Nova', 'Nimbus Sans', Arial, sans-serif",
+        "slug": "neo-grotesque",
+        "name": "Neo-Grotesque"
+      },
+      "categories": [
+        "sans-serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "'Nimbus Mono PS', 'Courier New', monospace",
+        "slug": "monospace-slab-serif",
+        "name": "Monospace Slab Serif"
+      },
+      "categories": [
+        "monospace"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "ui-monospace, 'Cascadia Code', 'Source Code Pro', Menlo, Consolas, 'DejaVu Sans Mono', monospace",
+        "slug": "monospace-code",
+        "name": "Monospace Code"
+      },
+      "categories": [
+        "monospace"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "Bahnschrift, 'DIN Alternate', 'Franklin Gothic Medium', 'Nimbus Sans Narrow', sans-serif-condensed, sans-serif",
+        "slug": "industrial",
+        "name": "Industrial"
+      },
+      "categories": [
+        "sans-serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "ui-rounded, 'Hiragino Maru Gothic ProN', Quicksand, Comfortaa, Manjari, 'Arial Rounded MT', 'Arial Rounded MT Bold', Calibri, source-sans-pro, sans-serif",
+        "slug": "rounded-sans",
+        "name": "Rounded Sans"
+      },
+      "categories": [
+        "sans-serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "Rockwell, 'Rockwell Nova', 'Roboto Slab', 'DejaVu Serif', 'Sitka Small', serif",
+        "slug": "slab-serif",
+        "name": "Slab Serif"
+      },
+      "categories": [
+        "serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "Superclarendon, 'Bookman Old Style', 'URW Bookman', 'URW Bookman L', 'Georgia Pro', Georgia, serif",
+        "slug": "antique",
+        "name": "Antique"
+      },
+      "categories": [
+        "serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "Didot, 'Bodoni MT', 'Noto Serif Display', 'URW Palladio L', P052, Sylfaen, serif",
+        "slug": "didone",
+        "name": "Didone"
+      },
+      "categories": [
+        "serif"
+      ]
+    },
+    {
+      "font_family_settings": {
+        "fontFamily": "'Segoe Print', 'Bradley Hand', Chilanka, TSCu_Comic, casual, cursive",
+        "slug": "handwritten",
+        "name": "Handwritten"
+      },
+      "categories": [
+        "handwriting"
+      ]
+    }
   ]
 }

--- a/index.php
+++ b/index.php
@@ -14,7 +14,7 @@ $modern_fonts_config = array (
     'slug'          => 'modern-fonts-stacks',
     'name'        => 'Modern Fonts Stacks',
     'description' => 'Stacks of modern systems fonts, not font face assets needed. The look will vary on each system.',
-    'src'         => path_join( __DIR__, 'collection-gutenberg-17.6.json' ),
+    'src'         => path_join( __DIR__, 'collection.json' ),
 );
 
 if ( function_exists( 'wp_register_font_collection' ) ) {

--- a/index.php
+++ b/index.php
@@ -3,7 +3,7 @@
 Plugin Name: Modern Fonts Stacks
 Plugin URI: https://github.com/matiasbenedetto/modern-fonts-stacks-for-wp-font-library/
 Description: Add a font collection to your WordPress Font Library.
-Version: 0.0.1
+Version: 0.0.3
 Author: Various Authors
 Author URI: https://wordpress.org/
 License: GPLv2 or later

--- a/index.php
+++ b/index.php
@@ -11,10 +11,10 @@ Text Domain: modern-fonts-stacks
 */
 
 $modern_fonts_config = array (
-    'id'          => 'modern-fonts-stacks',
+    'slug'          => 'modern-fonts-stacks',
     'name'        => 'Modern Fonts Stacks',
     'description' => 'Stacks of modern systems fonts, not font face assets needed. The look will vary on each system.',
-    'src'         => path_join( __DIR__, 'collection.json' ),
+    'src'         => path_join( __DIR__, 'collection-gutenberg-17.6.json' ),
 );
 
 if ( function_exists( 'wp_register_font_collection' ) ) {


### PR DESCRIPTION
## What?

Updates the implementation to match all the changes that will be added in GB 17.6  

## Why ?
see these PRs for reference:
https://github.com/WordPress/gutenberg/pull/57884

https://github.com/WordPress/gutenberg/pull/57688

https://github.com/WordPress/gutenberg/pull/57736

## Testing instructions:
1. Use the gutenberg version from this branch https://github.com/WordPress/gutenberg/pull/57688

2. Install and activate this version of the plugin: 
[modern-fonts-stacks-for-wp-font-library.zip](https://github.com/matiasbenedetto/modern-fonts-stacks-for-wp-font-library/files/14026871/modern-fonts-stacks-for-wp-font-library.zip)


3. Install a Font Family from this collection.
